### PR TITLE
fix: incorrect panic location

### DIFF
--- a/examples/assured_fail.rs
+++ b/examples/assured_fail.rs
@@ -1,0 +1,5 @@
+use meticulous::OptionExt;
+
+fn main() {
+    None::<i32>.assured("bad reason");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,18 +100,24 @@ where
     #[inline]
     #[track_caller]
     fn assured(self, reason: &str) -> T {
-        self.unwrap_or_else(|_| {
+        if let Ok(ok) = self {
+            ok
+        } else {
             panic!(
                 "the success was expected to be assured, but the error was returned: {}",
                 reason
-            )
-        })
+            );
+        }
     }
 
     #[inline]
     #[track_caller]
     fn verified(self, reason: &str) -> T {
-        self.unwrap_or_else(|_| panic!("the success was expected to be verified in the code earlier, but the error was returned: {}", reason))
+        if let Ok(ok) = self {
+            ok
+        } else {
+            panic!("the success was expected to be verified in the code earlier, but the error was returned: {}", reason);
+        }
     }
 }
 
@@ -197,18 +203,24 @@ impl<T> OptionExt<T> for Option<T> {
     #[inline]
     #[track_caller]
     fn assured(self, reason: &str) -> T {
-        self.unwrap_or_else(|| panic!("the value was assured to exist but was None: {}", reason))
+        if let Some(some) = self {
+            some
+        } else {
+            panic!("the value was assured to exist but was None: {}", reason);
+        }
     }
 
     #[inline]
     #[track_caller]
     fn verified(self, reason: &str) -> T {
-        self.unwrap_or_else(|| {
+        if let Some(some) = self {
+            some
+        } else {
             panic!(
                 "it was verified that value presents but None was returned: {}",
                 reason
-            )
-        })
+            );
+        }
     }
 }
 


### PR DESCRIPTION
`#[track_caller]` does not work on closures (https://github.com/rust-lang/rust/issues/87417), therefore `.unwrap_or_else(|| ...)` will panic with a message that points to a code location within this crate instead of the location of the caller.
To fix this, `Option`/`Result` should be destructured explicitly so that `panic!` happens inside of methods marked with `#[track_caller]`.